### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/anuragbaral/67e71907-ae34-47fd-921f-ab52d3081be1/7ec1251f-009f-43f1-bdd2-74f1301d23c3/_apis/work/boardbadge/48e4478e-1163-4f3b-b796-e4643549093c)](https://dev.azure.com/anuragbaral/67e71907-ae34-47fd-921f-ab52d3081be1/_boards/board/t/7ec1251f-009f-43f1-bdd2-74f1301d23c3/Microsoft.RequirementCategory)
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/anuragbaral/67e71907-ae34-47fd-921f-ab52d3081be1/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.